### PR TITLE
single image for mobile

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -349,8 +349,11 @@ slideShow {  0% {
 }
 }
 @media (max-width: 768px) {
+	.pic-wrapper {
+		display: none;
+	}
 	.jumbotron {
-		background: white;
+		background-image: url(../img/slides/phone.jpg);
 		background-position: center;
 		background-attachment: scroll;
 	}


### PR DESCRIPTION
only for smaller screens, removes fading slideshow and replaces it with a single, vertical image that fits phone screen better.